### PR TITLE
ci: pin GitHub actions hashes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
       frontend: ${{ steps.filter.outputs.ios }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: filter
         with:
           filters: |
@@ -35,15 +35,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Set up Node environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 16
       
       - name: Cache Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           java-version: "11"
           distribution: "adopt"
@@ -55,24 +55,24 @@ jobs:
         run: echo "::set-output name=path::$JAVA_HOME"
       
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1.1.0
       
       - name: Cache module node modules
-        uses: actions/cache@v3
+        uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         id: cache-node-modules
         with:
           path: node_modules
           key: yarn-${{ hashFiles('yarn.lock') }}
       
       - name: Cache Example application node modules
-        uses: actions/cache@v3
+        uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         id: cache-app-node-modules
         with:
           path: ./Example/node_modules
           key: yarn-${{ hashFiles('Example/yarn.lock') }}
 
       - name: Cache application pods
-        uses: actions/cache@v3
+        uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         id: cache-app-pods
         with:
           path: ./Example/ios/Pods
@@ -96,10 +96,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Restore node modules from cache
-        uses: actions/cache@v3
+        uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: node_modules
           key: yarn-${{ hashFiles('yarn.lock') }}
@@ -113,10 +113,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Restore node modules from cache
-        uses: actions/cache@v3
+        uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: node_modules
           key: yarn-${{ hashFiles('yarn.lock') }}
@@ -131,16 +131,16 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Restore node modules from cache
-        uses: actions/cache@v3
+        uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: node_modules
           key: yarn-${{ hashFiles('yarn.lock') }}
 
       - name: Restore application node modules from cache
-        uses: actions/cache@v3
+        uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: ./Example/node_modules
           key: yarn-${{ hashFiles('Example/yarn.lock') }}
@@ -158,22 +158,22 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Restore node modules from cache
-        uses: actions/cache@v3
+        uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: node_modules
           key: yarn-${{ hashFiles('yarn.lock') }}
 
       - name: Restore application node modules from cache
-        uses: actions/cache@v3
+        uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: ./Example/node_modules
           key: yarn-${{ hashFiles('Example/yarn.lock') }}
 
       - name: Restore application pods from cache
-        uses: actions/cache@v3
+        uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: ./Example/ios/Pods
           key: pods-${{ hashFiles('Example/ios/Podfile.lock') }}


### PR DESCRIPTION
  ## 📝 Summary

  
  This PR pins third-party GitHub Actions to full commit SHAs.
  Internal `ExodusMovement/...` actions are out of scope for this campaign and are intentionally not locked in these changes.
  This removes floating action references and reduces supply-chain risk by ensuring workflow execution uses reviewed, immutable upstream revisions instead of tags that can be moved.